### PR TITLE
Update to split audio/video bit rate setter functions.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 organization  := "org.toktok"
 name          := "tox4j-api"
-version       := "0.1.5"
+version       := "0.1.6"
 scalaVersion  := "2.11.12"
 
 bintrayVcsUrl := Some("https://github.com/TokTok/jvm-toxcore-api")

--- a/src/main/java/im/tox/tox4j/av/ToxAv.scala
+++ b/src/main/java/im/tox/tox4j/av/ToxAv.scala
@@ -98,16 +98,24 @@ trait ToxAv extends Closeable with ToxAvEventSynth {
   def callControl(friendNumber: ToxFriendNumber, @NotNull control: ToxavCallControl): Unit
 
   /**
-   * Set the audio and video bit rate to be used in subsequent audio frames.
+   * Set the audio bit rate to be used in subsequent audio frames.
    *
    * @param friendNumber The friend number of the friend for which to set the audio bit rate.
    * @param audioBitRate The new audio bit rate in Kb/sec. Set to 0 to disable audio sending.
    *                     Pass -1 to leave unchanged.
+   */
+  @throws[ToxavBitRateSetException]
+  def setAudioBitRate(friendNumber: ToxFriendNumber, audioBitRate: BitRate): Unit
+
+  /**
+   * Set the video bit rate to be used in subsequent audio frames.
+   *
+   * @param friendNumber The friend number of the friend for which to set the audio bit rate.
    * @param videoBitRate The new video bit rate in Kb/sec. Set to 0 to disable video sending.
    *                     Pass -1 to leave unchanged.
    */
   @throws[ToxavBitRateSetException]
-  def setBitRate(friendNumber: ToxFriendNumber, audioBitRate: BitRate, videoBitRate: BitRate): Unit
+  def setVideoBitRate(friendNumber: ToxFriendNumber, videoBitRate: BitRate): Unit
 
   /**
    * Send an audio frame to a friend.

--- a/src/main/java/im/tox/tox4j/av/callbacks/AudioBitRateCallback.scala
+++ b/src/main/java/im/tox/tox4j/av/callbacks/AudioBitRateCallback.scala
@@ -1,0 +1,19 @@
+package im.tox.tox4j.av.callbacks
+
+import im.tox.tox4j.av.data.BitRate
+import im.tox.tox4j.core.data.ToxFriendNumber
+
+/**
+ * The event is triggered when the network becomes too saturated for current
+ * bit rates at which point core suggests new bit rates.
+ */
+trait AudioBitRateCallback[ToxCoreState] {
+  /**
+   * @param friendNumber The friend number of the friend for which to set the
+   *                     audio bit rate.
+   * @param audioBitRate Suggested maximum audio bit rate in Kb/sec.
+   */
+  def audioBitRate(
+    friendNumber: ToxFriendNumber, audioBitRate: BitRate
+  )(state: ToxCoreState): ToxCoreState = state
+}

--- a/src/main/java/im/tox/tox4j/av/callbacks/ToxAvEventListener.scala
+++ b/src/main/java/im/tox/tox4j/av/callbacks/ToxAvEventListener.scala
@@ -3,6 +3,7 @@ package im.tox.tox4j.av.callbacks
 trait ToxAvEventListener[ToxCoreState]
   extends CallCallback[ToxCoreState]
   with CallStateCallback[ToxCoreState]
-  with BitRateStatusCallback[ToxCoreState]
+  with AudioBitRateCallback[ToxCoreState]
+  with VideoBitRateCallback[ToxCoreState]
   with AudioReceiveFrameCallback[ToxCoreState]
   with VideoReceiveFrameCallback[ToxCoreState]

--- a/src/main/java/im/tox/tox4j/av/callbacks/ToxAvEventSynth.scala
+++ b/src/main/java/im/tox/tox4j/av/callbacks/ToxAvEventSynth.scala
@@ -8,10 +8,11 @@ import im.tox.tox4j.core.data.ToxFriendNumber
 
 trait ToxAvEventSynth {
 
+  def invokeAudioBitRate(friendNumber: ToxFriendNumber, audioBitRate: BitRate): Unit
   def invokeAudioReceiveFrame(friendNumber: ToxFriendNumber, pcm: Array[Short], channels: AudioChannels, samplingRate: SamplingRate): Unit
-  def invokeBitRateStatus(friendNumber: ToxFriendNumber, audioBitRate: BitRate, videoBitRate: BitRate): Unit
   def invokeCall(friendNumber: ToxFriendNumber, audioEnabled: Boolean, videoEnabled: Boolean): Unit
   def invokeCallState(friendNumber: ToxFriendNumber, callState: util.EnumSet[ToxavFriendCallState]): Unit
+  def invokeVideoBitRate(friendNumber: ToxFriendNumber, videoBitRate: BitRate): Unit
   def invokeVideoReceiveFrame(friendNumber: ToxFriendNumber, width: Width, height: Height, y: Array[Byte], u: Array[Byte], v: Array[Byte], yStride: Int, uStride: Int, vStride: Int): Unit // scalastyle:ignore line.size.limit
 
 }

--- a/src/main/java/im/tox/tox4j/av/callbacks/VideoBitRateCallback.scala
+++ b/src/main/java/im/tox/tox4j/av/callbacks/VideoBitRateCallback.scala
@@ -7,14 +7,13 @@ import im.tox.tox4j.core.data.ToxFriendNumber
  * The event is triggered when the network becomes too saturated for current
  * bit rates at which point core suggests new bit rates.
  */
-trait BitRateStatusCallback[ToxCoreState] {
+trait VideoBitRateCallback[ToxCoreState] {
   /**
    * @param friendNumber The friend number of the friend for which to set the
    *                     video bit rate.
-   * @param audioBitRate Suggested maximum audio bit rate in Kb/sec.
    * @param videoBitRate Suggested maximum video bit rate in Kb/sec.
    */
-  def bitRateStatus(
-    friendNumber: ToxFriendNumber, audioBitRate: BitRate, videoBitRate: BitRate
+  def videoBitRate(
+    friendNumber: ToxFriendNumber, videoBitRate: BitRate
   )(state: ToxCoreState): ToxCoreState = state
 }

--- a/src/main/java/im/tox/tox4j/av/exceptions/ToxavBitRateSetException.java
+++ b/src/main/java/im/tox/tox4j/av/exceptions/ToxavBitRateSetException.java
@@ -15,13 +15,9 @@ public final class ToxavBitRateSetException extends ToxException<ToxavBitRateSet
      */
     FRIEND_NOT_IN_CALL,
     /**
-     * The audio bit rate passed was not one of the supported values.
+     * The bit rate passed was not one of the supported values.
      */
-    INVALID_AUDIO_BIT_RATE,
-    /**
-     * The video bit rate passed was not one of the supported values.
-     */
-    INVALID_VIDEO_BIT_RATE,
+    INVALID_BIT_RATE,
     /**
      * Synchronization error occurred.
      */

--- a/src/main/java/im/tox/tox4j/av/exceptions/exceptions.json
+++ b/src/main/java/im/tox/tox4j/av/exceptions/exceptions.json
@@ -40,8 +40,7 @@
   },
   "BitRateSet": {
     "SYNC": ["Synchronization error occurred."],
-    "INVALID_AUDIO_BIT_RATE": ["The audio bit rate passed was not one of the supported values."],
-    "INVALID_VIDEO_BIT_RATE": ["The video bit rate passed was not one of the supported values."],
+    "INVALID_BIT_RATE": ["The bit rate passed was not one of the supported values."],
     "FRIEND_NOT_FOUND": ["The friend_number passed did not designate a valid friend."],
     "FRIEND_NOT_IN_CALL": ["This client is currently not in a call with the friend."]
   },


### PR DESCRIPTION
Introduced in https://github.com/TokTok/c-toxcore/pull/578.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-toxcore-api/14)
<!-- Reviewable:end -->
