### PR TITLE
Update to next version of sbt-plugins.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 // Common tox4j build rules.
 resolvers += Resolver.bintrayIvyRepo("toktok", "sbt-plugins")
-addSbtPlugin("org.toktok" % "sbt-plugins" % "0.1.4")
+addSbtPlugin("org.toktok" % "sbt-plugins" % "0.1.5")


### PR DESCRIPTION
This changes the bintray license to GPL-3.0, making it agree with the
actual license of the project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-toxcore-api/20)
<!-- Reviewable:end -->
