### PR TITLE
Remove direct scalatest dependency.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,6 +25,5 @@ scala_test(
         ":jvm-toxcore-api",
         "@org_scalacheck_scalacheck//jar",
         "@org_scalactic_scalactic//jar:file",
-        "@org_scalatest_scalatest//jar:file",
     ],
 )


### PR DESCRIPTION
We depend on it transitively through scalacheck.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-toxcore-api/21)
<!-- Reviewable:end -->
