### PR TITLE
Add error enum for new PROXY_WITH_UDP error.

### DIFF
--- a/src/main/java/im/tox/tox4j/core/exceptions/ToxNewException.java
+++ b/src/main/java/im/tox/tox4j/core/exceptions/ToxNewException.java
@@ -51,6 +51,12 @@ public final class ToxNewException extends ToxException<ToxNewException.Code> {
      * The proxy address passed could not be resolved.
      */
     PROXY_NOT_FOUND,
+    /**
+     * UDP was enabled together with a proxy. This is a security issue, because
+     * UDP connections are never proxied. You must disable UDP in order to use a
+     * proxy.
+     */
+    PROXY_WITH_UDP,
   }
 
   public ToxNewException(@NotNull Code code) {

--- a/src/main/java/im/tox/tox4j/core/exceptions/exceptions.json
+++ b/src/main/java/im/tox/tox4j/core/exceptions/exceptions.json
@@ -118,6 +118,11 @@
       "When loading from badly formatted data, some data may have been loaded,",
       "and the rest is discarded. Passing an invalid length parameter also",
       "causes this error."
+    ],
+    "PROXY_WITH_UDP": [
+      "UDP was enabled together with a proxy. This is a security issue, because",
+      "UDP connections are never proxied. You must disable UDP in order to use a",
+      "proxy."
     ]
   },
   "FriendCustomPacket": {


### PR DESCRIPTION
See https://github.com/TokTok/c-toxcore/pull/929.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-toxcore-api/22)
<!-- Reviewable:end -->
