### PR TITLE
Upgrade dependencies to their latest version where possible.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 organization  := "org.toktok"
 name          := "tox4j-api"
-version       := "0.2.0"
+version       := "0.2.1"
 scalaVersion  := "2.11.12"
 
 bintrayVcsUrl := Some("https://github.com/TokTok/jvm-toxcore-api")
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
 
 // Test dependencies.
 libraryDependencies ++= Seq(
-  "org.scalacheck" %% "scalacheck" % "1.13.5",
+  "org.scalacheck" %% "scalacheck" % "1.14.1",
   "org.scalatest" %% "scalatest" % "3.0.1"
 ) map (_ % Test)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 // Common tox4j build rules.
 resolvers += Resolver.bintrayIvyRepo("toktok", "sbt-plugins")
-addSbtPlugin("org.toktok" % "sbt-plugins" % "0.1.5")
+addSbtPlugin("org.toktok" % "sbt-plugins" % "0.1.6")


### PR DESCRIPTION
scalatest can't be upgraded, because from 3.0.1 to 3.1.1 the API changed
incompatibly and property based tests no longer work the same way. I
can't be bothered to figure it out for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-toxcore-api/26)
<!-- Reviewable:end -->
